### PR TITLE
[#1] 카테고리 기반 상품 조회 기능

### DIFF
--- a/src/main/java/ksh/emall/BaseEntity.java
+++ b/src/main/java/ksh/emall/BaseEntity.java
@@ -1,4 +1,4 @@
-package ksh;
+package ksh.emall;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;

--- a/src/main/java/ksh/emall/common/dto/response/PageResponseDto.java
+++ b/src/main/java/ksh/emall/common/dto/response/PageResponseDto.java
@@ -1,0 +1,26 @@
+package ksh.emall.common.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PageResponseDto<T> {
+
+    private long page;
+    private long size;;
+    private long totalPages;
+    private List<T> content;
+
+    public static <T> PageResponseDto<T> from(Page<T> page) {
+        return PageResponseDto.<T>builder()
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalPages(page.getTotalPages())
+            .content(page.getContent())
+            .build();
+    }
+}

--- a/src/main/java/ksh/emall/product/controller/ProductController.java
+++ b/src/main/java/ksh/emall/product/controller/ProductController.java
@@ -1,0 +1,36 @@
+package ksh.emall.product.controller;
+
+import jakarta.validation.Valid;
+import ksh.emall.common.dto.response.PageResponseDto;
+import ksh.emall.product.dto.request.ProductRequestDto;
+import ksh.emall.product.dto.response.ProductResponseDto;
+import ksh.emall.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping("/products")
+    public ResponseEntity<PageResponseDto> findProductsByCategory(
+        Pageable pageable,
+        @Valid ProductRequestDto productRequest
+    ) {
+        Page<ProductResponseDto> page = productService.findProductsByCategory(
+                pageable,
+                productRequest
+            )
+            .map(ProductResponseDto::from);
+
+        PageResponseDto<ProductResponseDto> response = PageResponseDto.from(page);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/ksh/emall/product/dto/request/ProductRequestDto.java
+++ b/src/main/java/ksh/emall/product/dto/request/ProductRequestDto.java
@@ -18,10 +18,5 @@ public class ProductRequestDto {
     private ProductSortCriteria criteria;
 
     @NotNull(message = "정렬 방향은 필수입니다.")
-    @Getter(AccessLevel.NONE)
     private Boolean isAscending;
-
-    public Boolean isAscending() {
-        return this.isAscending;
-    }
 }

--- a/src/main/java/ksh/emall/product/dto/request/ProductRequestDto.java
+++ b/src/main/java/ksh/emall/product/dto/request/ProductRequestDto.java
@@ -1,0 +1,27 @@
+package ksh.emall.product.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import ksh.emall.product.entity.ProductCategory;
+import ksh.emall.product.enums.sort.ProductSortCriteria;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductRequestDto {
+
+    @NotNull(message = "제품 카테고리는 필수입니다.")
+    private ProductCategory category;
+
+    @NotNull(message = "제품 정렬 기준은 필수입니다.")
+    private ProductSortCriteria criteria;
+
+    @NotNull(message = "정렬 방향은 필수입니다.")
+    @Getter(AccessLevel.NONE)
+    private Boolean isAscending;
+
+    public Boolean isAscending() {
+        return this.isAscending;
+    }
+}

--- a/src/main/java/ksh/emall/product/dto/response/ProductResponseDto.java
+++ b/src/main/java/ksh/emall/product/dto/response/ProductResponseDto.java
@@ -1,0 +1,38 @@
+package ksh.emall.product.dto.response;
+
+import ksh.emall.product.entity.DeliveryType;
+import ksh.emall.product.entity.Product;
+import ksh.emall.product.entity.ProductReviewStat;
+import ksh.emall.product.repository.projection.ProductWithReviewStat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ProductResponseDto {
+
+    private String name;
+    private int price;
+    private DeliveryType deliveryType;
+    private LocalDate guaranteedDeliveryDate;
+    private double averageScore;
+    private int reviewCount;
+    private String imageUrl;
+
+    public static ProductResponseDto from(ProductWithReviewStat productWithReviewStat) {
+        Product product = productWithReviewStat.getProduct();
+        ProductReviewStat reviewStat = productWithReviewStat.getReviewStat();
+
+        return ProductResponseDto.builder()
+            .name(product.getName())
+            .price(product.getPrice())
+            .deliveryType(product.getDeliveryType())
+            .guaranteedDeliveryDate(LocalDate.now().plusDays(product.getExpectedDeliveryDays()))
+            .averageScore(reviewStat.getAverageReviewScore())
+            .reviewCount(reviewStat.getReviewCount())
+            .imageUrl(product.getImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/ksh/emall/product/entity/DeliveryType.java
+++ b/src/main/java/ksh/emall/product/entity/DeliveryType.java
@@ -1,0 +1,7 @@
+package ksh.emall.product.entity;
+
+public enum DeliveryType {
+    NORMAL,
+    FAST,
+    FRESH
+}

--- a/src/main/java/ksh/emall/product/entity/Product.java
+++ b/src/main/java/ksh/emall/product/entity/Product.java
@@ -1,0 +1,41 @@
+package ksh.emall.product.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import ksh.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Integer price;
+
+    private DeliveryType deliveryType;
+
+    private Integer quantity;
+
+    private Integer expectedDeliveryDays;
+
+    private String imageUrl;
+
+    @SQLDelete(sql = "update order set is_deleted = true where id = ?")
+    @Where(clause = "isDeleted = 0")
+    private boolean isDeleted;
+}

--- a/src/main/java/ksh/emall/product/entity/Product.java
+++ b/src/main/java/ksh/emall/product/entity/Product.java
@@ -1,7 +1,7 @@
 package ksh.emall.product.entity;
 
 import jakarta.persistence.*;
-import ksh.BaseEntity;
+import ksh.emall.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/ksh/emall/product/entity/Product.java
+++ b/src/main/java/ksh/emall/product/entity/Product.java
@@ -1,9 +1,6 @@
 package ksh.emall.product.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import ksh.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,6 +19,9 @@ public class Product extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ProductCategory category;
 
     private String name;
 

--- a/src/main/java/ksh/emall/product/entity/Product.java
+++ b/src/main/java/ksh/emall/product/entity/Product.java
@@ -14,6 +14,8 @@ import org.hibernate.annotations.Where;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@SQLDelete(sql = "update order set is_deleted = true where id = ?")
+@Where(clause = "isDeleted = 0")
 public class Product extends BaseEntity {
 
     @Id
@@ -35,7 +37,5 @@ public class Product extends BaseEntity {
 
     private String imageUrl;
 
-    @SQLDelete(sql = "update order set is_deleted = true where id = ?")
-    @Where(clause = "isDeleted = 0")
     private boolean isDeleted;
 }

--- a/src/main/java/ksh/emall/product/entity/ProductCategory.java
+++ b/src/main/java/ksh/emall/product/entity/ProductCategory.java
@@ -1,0 +1,10 @@
+package ksh.emall.product.entity;
+
+public enum ProductCategory {
+    FASHION,
+    BEAUTY,
+    FOOD,
+    KITCHENWARE,
+    HOUSEHOLD,
+    ELECTRONICS,
+}

--- a/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
+++ b/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
@@ -4,7 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import ksh.BaseEntity;
+import ksh.emall.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
+++ b/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
@@ -1,0 +1,35 @@
+package ksh.emall.product.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import ksh.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductReviewStat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Double averageReviewScore;
+
+    private Integer reviewCount;
+
+    private Long productId;
+
+    @SQLDelete(sql = "update order set is_deleted = true where id = ?")
+    @Where(clause = "isDeleted = 0")
+    private boolean isDeleted;
+}

--- a/src/main/java/ksh/emall/product/entity/ProductSalesStat.java
+++ b/src/main/java/ksh/emall/product/entity/ProductSalesStat.java
@@ -4,7 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import ksh.BaseEntity;
+import ksh.emall.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/ksh/emall/product/entity/ProductSalesStat.java
+++ b/src/main/java/ksh/emall/product/entity/ProductSalesStat.java
@@ -1,0 +1,27 @@
+package ksh.emall.product.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import ksh.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProductSalesStat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long soldCount;
+
+    private Long productId;
+}

--- a/src/main/java/ksh/emall/product/enums/sort/ProductSortCriteria.java
+++ b/src/main/java/ksh/emall/product/enums/sort/ProductSortCriteria.java
@@ -1,0 +1,7 @@
+package ksh.emall.product.enums.sort;
+
+public enum ProductSortCriteria {
+    PRICE,
+    SOLD_COUNT,
+    REGISTER_DATE
+}

--- a/src/main/java/ksh/emall/product/repository/ProductQueryRepository.java
+++ b/src/main/java/ksh/emall/product/repository/ProductQueryRepository.java
@@ -1,0 +1,12 @@
+package ksh.emall.product.repository;
+
+import ksh.emall.product.entity.ProductCategory;
+import ksh.emall.product.enums.sort.ProductSortCriteria;
+import ksh.emall.product.repository.projection.ProductWithReviewStat;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductQueryRepository {
+
+    Page<ProductWithReviewStat> findByCategoryWithReviewStat(Pageable pageable, ProductCategory category, ProductSortCriteria criteria, boolean isAscending);
+}

--- a/src/main/java/ksh/emall/product/repository/ProductQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/product/repository/ProductQueryRepositoryImpl.java
@@ -31,10 +31,16 @@ public class ProductQueryRepositoryImpl implements ProductQueryRepository {
         boolean isAscending
     ) {
         List<ProductWithReviewStat> content = queryFactory
-            .select(Projections.constructor(ProductWithReviewStat.class, product, productReviewStat))
+            .select(Projections.constructor(
+                ProductWithReviewStat.class,
+                product,
+                productReviewStat
+            ))
             .from(product)
             .join(productReviewStat)
-            .on(productReviewStat.productId.eq(product.id))
+                .on(productReviewStat.productId.eq(product.id))
+            .join(productSalesStat)
+                .on(productSalesStat.productId.eq(product.id))
             .where(product.category.eq(category))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())

--- a/src/main/java/ksh/emall/product/repository/ProductQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/product/repository/ProductQueryRepositoryImpl.java
@@ -1,0 +1,64 @@
+package ksh.emall.product.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ksh.emall.product.entity.*;
+import ksh.emall.product.enums.sort.ProductSortCriteria;
+import ksh.emall.product.repository.projection.ProductWithReviewStat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static ksh.emall.product.entity.QProduct.*;
+import static ksh.emall.product.entity.QProductReviewStat.*;
+import static ksh.emall.product.entity.QProductSalesStat.*;
+
+@RequiredArgsConstructor
+public class ProductQueryRepositoryImpl implements ProductQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ProductWithReviewStat> findByCategoryWithReviewStat(
+        Pageable pageable,
+        ProductCategory category,
+        ProductSortCriteria criteria,
+        boolean isAscending
+    ) {
+        List<ProductWithReviewStat> content = queryFactory
+            .select(Projections.constructor(ProductWithReviewStat.class, product, productReviewStat))
+            .from(product)
+            .join(productReviewStat)
+            .on(productReviewStat.productId.eq(product.id))
+            .where(product.category.eq(category))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(buildProductOrderSpecifier(criteria, isAscending))
+            .fetch();
+
+        Long count = queryFactory.select(product.count())
+            .from(product)
+            .fetchOne();
+
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    OrderSpecifier buildProductOrderSpecifier(ProductSortCriteria criteria, boolean isAscending) {
+        Order direction = isAscending ? Order.ASC : Order.DESC;
+
+        if(criteria == ProductSortCriteria.PRICE) {
+            return new OrderSpecifier(direction, product.price);
+        }
+
+        if(criteria == ProductSortCriteria.SOLD_COUNT) {
+            return new OrderSpecifier(Order.DESC, productSalesStat.soldCount);
+        }
+
+        return new OrderSpecifier(direction, product.createdAt);
+    }
+}

--- a/src/main/java/ksh/emall/product/repository/ProductRepository.java
+++ b/src/main/java/ksh/emall/product/repository/ProductRepository.java
@@ -3,5 +3,5 @@ package ksh.emall.product.repository;
 import ksh.emall.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductQueryRepository {
 }

--- a/src/main/java/ksh/emall/product/repository/ProductRepository.java
+++ b/src/main/java/ksh/emall/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package ksh.emall.product.repository;
+
+import ksh.emall.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/ksh/emall/product/repository/projection/ProductWithReviewStat.java
+++ b/src/main/java/ksh/emall/product/repository/projection/ProductWithReviewStat.java
@@ -1,0 +1,14 @@
+package ksh.emall.product.repository.projection;
+
+import ksh.emall.product.entity.Product;
+import ksh.emall.product.entity.ProductReviewStat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductWithReviewStat {
+
+    private Product product;
+    private ProductReviewStat reviewStat;
+}

--- a/src/main/java/ksh/emall/product/service/ProductService.java
+++ b/src/main/java/ksh/emall/product/service/ProductService.java
@@ -1,0 +1,28 @@
+package ksh.emall.product.service;
+
+import ksh.emall.product.dto.request.ProductRequestDto;
+import ksh.emall.product.repository.ProductRepository;
+import ksh.emall.product.repository.projection.ProductWithReviewStat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public Page<ProductWithReviewStat> findProductsByCategory(
+        Pageable pageable,
+        ProductRequestDto productRequest
+    ) {
+        return productRepository.findByCategoryWithReviewStat(
+            pageable,
+            productRequest.getCategory(),
+            productRequest.getCriteria(),
+            productRequest.isAscending()
+        );
+    }
+}

--- a/src/main/java/ksh/emall/product/service/ProductService.java
+++ b/src/main/java/ksh/emall/product/service/ProductService.java
@@ -22,7 +22,7 @@ public class ProductService {
             pageable,
             productRequest.getCategory(),
             productRequest.getCriteria(),
-            productRequest.isAscending()
+            productRequest.getIsAscending()
         );
     }
 }


### PR DESCRIPTION
# 주요 구현 사항

## 상품 도메인 엔티티 설계

### Product
상품을 나타내는 엔티티입니다. 하나의 상품에 대한 기본적인 정보와 배송 정보를 포함하고 있습니다.
- **`category`** : 상품이 속한 카테고리 (`enum`)
- **`name`** : 상품명
- **`price`** : 상품 가격
- **`deliveryType`** : 상품의 배송 방식 (예: 로켓배송, 로켓프레시)
- **`quantity`** : 현재 재고 수량
- **`expectedDeliveryDays`** : 예상 배송 소요일로, 보장 배송 날짜 계산에 사용됩니다.
- **`imageUrl`** : 상품의 대표 이미지 URL

### ProductReviewStat
상품의 리뷰 통계를 나타내는 엔티티입니다.  
Product 테이블에 캐싱 정보를 함께 두면, 캐시 갱신 시 락으로 인해 상품 조회 성능에 영향을 줄 수 있습니다. 또한, 매번 전체 리뷰 데이터를 조회하여 통계를 계산하는 것은 오버헤드가 크기 때문에, 통계 정보를 별도로 캐싱하여 관리하기 위해 엔티티를 분리하였습니다.
- **`averageReviewScore`** : 평균 리뷰 점수
- **`reviewCount`** : 총 리뷰 수

### ProductSalesStat
상품의 판매 통계를 나타내는 엔티티입니다.  
Product 테이블에 캐싱 정보를 함께 두면, 캐시 갱신 시 락으로 인해 상품 조회 성능에 영향을 줄 수 있습니다. 또한 매번 통계 쿼리를 수행하지 않고 캐싱된 통계 정보를 활용하기 위해 존재합니다.
- **`soldCount`** : 누적 판매량

## 카테고리별 상품 조회 기능

사용자가 특정 카테고리를 선택하면, 해당 카테고리에 속한 상품 목록을 페이징하여 제공합니다.  
상품 목록은 사용자가 선택한 정렬 기준에 따라 정렬되며, 다음 기준 중 하나를 선택할 수 있습니다:

- 가격
- 판매량
- 등록일

정렬 기준마다 별도의 엔드포인트를 만들 경우 정렬 기준이 추가되거나 변경될 때 유지보수가 어려울 수 있습니다.  
이를 해결하기 위해 Querydsl을 활용해 정렬 기준을 동적으로 생성하고, 이를 기반으로 동적 쿼리를 구성하여 조회하고 있습니다.

---

# 공유 사항
- 현재 연관 관계가 설정되어 있지 않아, 연관된 엔티티를 함께 조회하려면 Tuple 또는 별도의 프로젝션용 DTO를 사용해야 합니다. 하지만 쿼리마다 조회 항목이 다르기 때문에 매번 DTO를 새로 만드는 것이 과연 최선인지 고민이 됩니다. 혹시 더 나은 방법이 있을까요?

- 카테고리는 제품 필터링 조건 중 하나로, 현재는 URL에 반영하지 않고 쿼리 파라미터로 전달하고 있습니다. 필터 조건을 URL에 포함시키는 것은 RESTful하지 않다고 알고 있어서인데, 지금의 경우 /products/food처럼 경로 변수로 표현하면 자원의 구조를 더 명확히 드러낼 수 있어 RESTful하다고 생각됩니다. 어떤 방식이 더 적절할지 궁금합니다.

- 정렬 기준이 3개만 되어도 동적으로 Querydsl로 `order by`절을 생성하는 메소드에서 if문 분기가 늘어나고 있어, 확장성이 떨어지는 구조로 보입니다. 이런 문제를 해결하기 위한 방법이 있을지 아니면 정렬 기준별로 api를 분리하는 게 좋았을지 궁금합니다. 

- Spring에서는 요청 파라미터를 이용해 자동으로 Pageable을 생성하는 기능이 있는 것으로 알고 있습니다. 다만 이 기능을 사용하지 않고 정렬 기준을 별도의 요청 DTO를 사용하는 이유는, Pageable 자동 생성은 누락된 값에 대한 검증이 어렵고, Querydsl에서 정렬 조건을 만들기 `Sort`객체를 `OrderSpecifier`로 따로 매핑하는 과정이 필요하기 때문입니다. 이런한 정렬 처리 방식에 대해 어떻게 생각하시나요?

- 마지막으로, 원할한 리뷰 또는 협업을 위해 전체적으로 주석을 다는 것에 대해 어떻게 생각하시나요?