### PR TITLE
[#4] ErrorCode 기반 예외 처리 시스템 구현

### DIFF
--- a/src/main/java/ksh/emall/common/config/MessageSourceConfig.java
+++ b/src/main/java/ksh/emall/common/config/MessageSourceConfig.java
@@ -1,0 +1,24 @@
+package ksh.emall.common.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+@Configuration
+public class MessageSourceConfig {
+
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages");
+        messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
+        messageSource.setUseCodeAsDefaultMessage(true);
+        messageSource.setFallbackToSystemLocale(false);
+        messageSource.setDefaultLocale(Locale.KOREA);
+        return messageSource;
+    }
+}

--- a/src/main/java/ksh/emall/common/dto/response/ErrorResponseDto.java
+++ b/src/main/java/ksh/emall/common/dto/response/ErrorResponseDto.java
@@ -1,0 +1,17 @@
+package ksh.emall.common.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponseDto {
+
+    private int status;
+    private String code;
+    private String message;
+
+    public static ErrorResponseDto of(int status, String code, String message) {
+        return new ErrorResponseDto(status, code, message);
+    }
+}

--- a/src/main/java/ksh/emall/common/exception/CustomException.java
+++ b/src/main/java/ksh/emall/common/exception/CustomException.java
@@ -1,0 +1,19 @@
+package ksh.emall.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final List<Object> messageArgs;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.messageArgs = List.of();
+    }
+}

--- a/src/main/java/ksh/emall/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/emall/common/exception/ErrorCode.java
@@ -1,0 +1,14 @@
+package ksh.emall.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    INTERNAL_SERVER_ERROR(500, "internal.server.error");
+
+    private final int status;
+    private final String messageKey;
+}

--- a/src/main/java/ksh/emall/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/ksh/emall/common/exception/GlobalControllerAdvice.java
@@ -1,0 +1,78 @@
+package ksh.emall.common.exception;
+
+import ksh.emall.common.dto.response.ErrorResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Locale;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+@Slf4j
+public class GlobalControllerAdvice {
+
+    private final MessageSource messageSource;
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponseDto> handleBindException(BindException e) {
+        String message = e.getBindingResult()
+            .getAllErrors()
+            .get(0)
+            .getDefaultMessage();
+
+        log.info("예외 정보 : {}", message);
+
+        ErrorResponseDto response = ErrorResponseDto.of(
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.name(),
+            message
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(response);
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponseDto> handleCustomException(CustomException e, Locale locale) {
+        ErrorCode errorCode = e.getErrorCode();
+        String message = messageSource.getMessage(
+            errorCode.getMessageKey(),
+            e.getMessageArgs().toArray(),
+            locale
+        );
+
+        log.info("예외 정보 : {} {}", errorCode.name(), message);
+
+        ErrorResponseDto response = ErrorResponseDto.of(
+            errorCode.getStatus(),
+            errorCode.name(),
+            message
+        );
+
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleException(Exception e, Locale locale) {
+        log.info("예외 정보 : {}", e.getMessage());
+
+        ErrorResponseDto response = ErrorResponseDto.of(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            HttpStatus.INTERNAL_SERVER_ERROR.name(),
+            e.getMessage()
+        );
+
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(response);
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+internal.server.error=서버 내부에 문제가 발생했습니다.


### PR DESCRIPTION
# 주요 구현 사항
## Errorcode 기반 예외 처리 시스템
### 도입 이유  
기존에는 예외 발생 시 `IllegalArgumentException` 만 던졌고 예외 메세지를 하드코딩 했습니다.
이 방식은 다음과 같은 문제를 유발했습니다:
  - 예외 메시지 변경 시 사용된 모든 위치를 직접 수정해야 하며 유지 보수 비용이 올라감
  - 프론트엔드가 알 수 있는 예외 상황에 대한 정보가 부족
  - 프론트엔드가 문자열 비교로 예외 상황을 구분해야 해 로직이 복잡해짐
  - 다국어 지원이 어려움
이러한 문제를 해결하기 위해 `ErrorCode`를 도입하고, 메시지 소스와 연동하여 일관된 예외 처리 시스템을 구성했습니다.

### 구조
1. **ErrorCode enum 정의**  
   - HTTP 상태 코드와 메시지 키를 쌍으로 갖는 예외 코드 정의  
   - 예: `MEMBER_NOT_FOUND(400, "error.400.member.not.found")`

2. **messages.properties 추가**  
   - 각 예외 코드에 대응하는 실제 메시지를 별도 파일로 관리  
   - 예: `error.400.member.not.found=존재하지 않는 회원입니다.`

3. **CustomException 구현**  
   - `ErrorCode`와 메시지 포맷팅에 필요한 인자(`messageArgs`)를 담는 런타임 예외 클래스 구현

4. **ErrorResponseDto 작성**  
   - `status`, `code`, `message` 필드를 포함하는 공통 에러 응답 포맷 정의

5. **GlobalControllerAdvice 도입**  
   - `@ExceptionHandler(CustomException.class)`에서 `ErrorCode` 기반 메시지 조회 및 `ErrorResponseDto` 생성
   - 기타 예외는 500 에러로 처리

### 예외 처리 흐름
1. 서비스 또는 컨트롤러에서 예외가 발생하면
2. GlobalControllerAdvice에서 해당 예외를 처리합니다
3. ExceptionHandler는 ErrorCode 속 메세지 키를 이용해 메시지 소스를 통해 메시지를 조회하고
4. 조회한 메세지와  ErrorCode를 이용해 ErrorResponseDto 생성 후 ResponseEntity로 클라이언트에 반환합니다.