### PR TITLE
[#7] 리뷰 등록 기능 구현

### DIFF
--- a/src/main/java/ksh/emall/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/emall/common/exception/ErrorCode.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    PRODUCT_NOT_FOUND(404, "product.not.found"),
+
     INTERNAL_SERVER_ERROR(500, "internal.server.error");
 
     private final int status;

--- a/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
+++ b/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
@@ -17,6 +17,8 @@ import org.hibernate.annotations.Where;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@SQLDelete(sql = "update order set is_deleted = true where id = ?")
+@Where(clause = "isDeleted = 0")
 public class ProductReviewStat extends BaseEntity {
 
     @Id
@@ -29,7 +31,5 @@ public class ProductReviewStat extends BaseEntity {
 
     private Long productId;
 
-    @SQLDelete(sql = "update order set is_deleted = true where id = ?")
-    @Where(clause = "isDeleted = 0")
     private boolean isDeleted;
 }

--- a/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
+++ b/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
@@ -32,4 +32,15 @@ public class ProductReviewStat extends BaseEntity {
     private Long productId;
 
     private boolean isDeleted;
+
+    public void addReviewScore(int newScore) {
+        if(reviewCount == 0){
+            this.reviewCount = 0;
+            this.averageReviewScore = 0.0;
+        }
+
+        double totalScore = this.averageReviewScore * this.reviewCount;
+        this.reviewCount++;
+        this.averageReviewScore = (totalScore + newScore) / this.reviewCount;
+    }
 }

--- a/src/main/java/ksh/emall/product/repository/ProductRepository.java
+++ b/src/main/java/ksh/emall/product/repository/ProductRepository.java
@@ -1,7 +1,16 @@
 package ksh.emall.product.repository;
 
+import ksh.emall.common.exception.CustomException;
+import ksh.emall.common.exception.ErrorCode;
 import ksh.emall.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductQueryRepository {
+
+    default Product getById(Long id) {
+        return findById(id)
+            .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND, List.of(id)));
+    }
 }

--- a/src/main/java/ksh/emall/product/repository/ProductReviewStatRepository.java
+++ b/src/main/java/ksh/emall/product/repository/ProductReviewStatRepository.java
@@ -1,15 +1,18 @@
 package ksh.emall.product.repository;
 
+import jakarta.persistence.LockModeType;
 import ksh.emall.common.exception.CustomException;
 import ksh.emall.common.exception.ErrorCode;
 import ksh.emall.product.entity.ProductReviewStat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ProductReviewStatRepository extends JpaRepository<ProductReviewStat, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     default ProductReviewStat getByProductId(Long productId) {
         return findByProductId(productId)
             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND, List.of(productId)));

--- a/src/main/java/ksh/emall/product/repository/ProductReviewStatRepository.java
+++ b/src/main/java/ksh/emall/product/repository/ProductReviewStatRepository.java
@@ -1,0 +1,19 @@
+package ksh.emall.product.repository;
+
+import ksh.emall.common.exception.CustomException;
+import ksh.emall.common.exception.ErrorCode;
+import ksh.emall.product.entity.ProductReviewStat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductReviewStatRepository extends JpaRepository<ProductReviewStat, Long> {
+
+    default ProductReviewStat getByProductId(Long productId) {
+        return findByProductId(productId)
+            .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND, List.of(productId)));
+    }
+
+    Optional<ProductReviewStat> findByProductId(Long productId);
+}

--- a/src/main/java/ksh/emall/review/controller/ReviewController.java
+++ b/src/main/java/ksh/emall/review/controller/ReviewController.java
@@ -1,0 +1,30 @@
+package ksh.emall.review.controller;
+
+import jakarta.validation.Valid;
+import ksh.emall.review.dto.request.ReviewRegisterRequestDto;
+import ksh.emall.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/products/{productId}/reviews")
+    public ResponseEntity<Void> register(
+        @PathVariable("productId") long productId,
+        @Valid @RequestBody ReviewRegisterRequestDto request
+    ) {
+        reviewService.register(productId, request);
+
+        return ResponseEntity
+            .noContent()
+            .build();
+    }
+}

--- a/src/main/java/ksh/emall/review/dto/request/ReviewRegisterRequestDto.java
+++ b/src/main/java/ksh/emall/review/dto/request/ReviewRegisterRequestDto.java
@@ -1,0 +1,27 @@
+package ksh.emall.review.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
+
+@Getter
+@AllArgsConstructor
+public class ReviewRegisterRequestDto {
+
+    @NotNull(message = "리뷰 등록자의 id는 필수입니다.")
+    private Long memberId;
+
+    @NotBlank(message = "리뷰 제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "리뷰 내용은 필수입니다.")
+    @Size(min = 20, max = 1500, message = "리뷰는 20자 이상 1500자 이하로 작성해야 합니다.")
+    private String body;
+
+    @NotNull(message = "리뷰 별점은 필수입니다.")
+    @Range(min = 0, max = 5, message = "별점은 0이상 5이하입니다.")
+    private Integer score;
+}

--- a/src/main/java/ksh/emall/review/entity/Review.java
+++ b/src/main/java/ksh/emall/review/entity/Review.java
@@ -1,0 +1,41 @@
+package ksh.emall.review.entity;
+
+import jakarta.persistence.*;
+import ksh.emall.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLDelete(sql = "update order set is_deleted = true where id = ?")
+@Where(clause = "isDeleted = 0")
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer score;
+
+    private String title;
+
+    @Column(length = 1500)
+    private String body;
+
+    private Integer likeCount;
+
+    private String imageUrl;
+
+    private Long memberId;
+
+    private Long productId;
+
+    private boolean isDeleted;
+}

--- a/src/main/java/ksh/emall/review/repository/ReviewRepository.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package ksh.emall.review.repository;
+
+import ksh.emall.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/ksh/emall/review/service/ReviewService.java
+++ b/src/main/java/ksh/emall/review/service/ReviewService.java
@@ -1,0 +1,40 @@
+package ksh.emall.review.service;
+
+import ksh.emall.product.entity.ProductReviewStat;
+import ksh.emall.product.repository.ProductRepository;
+import ksh.emall.product.repository.ProductReviewStatRepository;
+import ksh.emall.review.dto.request.ReviewRegisterRequestDto;
+import ksh.emall.review.entity.Review;
+import ksh.emall.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ProductRepository productRepository;
+    private final ProductReviewStatRepository productReviewStatRepository;
+
+
+    @Transactional
+    public void register(long productId, ReviewRegisterRequestDto request) {
+        productRepository.getById(productId);
+        Review review = createReview(productId, request);
+        reviewRepository.save(review);
+        ProductReviewStat productReviewStat = productReviewStatRepository.getById(productId);
+        productReviewStat.addReviewScore(request.getScore());
+    }
+
+    private static Review createReview(long productId, ReviewRegisterRequestDto request) {
+        return Review.builder()
+            .score(request.getScore())
+            .title(request.getTitle())
+            .body(request.getBody())
+            .memberId(request.getMemberId())
+            .productId(productId)
+            .build();
+    }
+}

--- a/src/main/java/ksh/emall/review/service/ReviewService.java
+++ b/src/main/java/ksh/emall/review/service/ReviewService.java
@@ -24,7 +24,7 @@ public class ReviewService {
         productRepository.getById(productId);
         Review review = createReview(productId, request);
         reviewRepository.save(review);
-        ProductReviewStat productReviewStat = productReviewStatRepository.getById(productId);
+        ProductReviewStat productReviewStat = productReviewStatRepository.getByProductId(productId);
         productReviewStat.addReviewScore(request.getScore());
     }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,1 +1,3 @@
+product.not.found={0}는 존재하지 않는 제품입니다.
+
 internal.server.error=서버 내부에 문제가 발생했습니다.


### PR DESCRIPTION
# 주요 구현 사항
## 리뷰 엔티티 설계
리뷰를 나타내는 `Review` 엔티티를 정의하였습니다.  
주요 필드는 다음과 같습니다:
- `score` : 리뷰 평점 (0~5)
- `title` : 리뷰 제목
- `body` : 리뷰 본문 (최대 1500자)  
  - `@Column(length = 1500)` 을 통해 길이 제한 적용  
  - 최대 길이여도 수 KB 수준이므로 CLOB이 아닌 일반 문자열 타입으로 저장
- `likeCount` : 리뷰에 대한 좋아요 수
- `imageUrl` : 리뷰에 첨부된 이미지 URL
- `memberId` : 리뷰 작성자 ID
- `productId` : 리뷰 대상 상품 ID

## 리뷰 등록 구현
리뷰 등록 과정은 다음과 같습니다.
1. 전달받은 `productId`로 해당 상품을 조회하여 유효한 상품인지 검증합니다.  
2. 요청 정보를 기반으로 `Review` 엔티티를 생성합니다.  
3. 리뷰가 새로 등록되었으므로, 리뷰 통계 캐싱 엔티티인 `ProductReviewStat`을 업데이트합니다.

리뷰 등록 후에는 일반적으로 화면에 "리뷰가 정상적으로 등록되었습니다"와 같은 안내만 표시되는 경우가 많습니다.
따라서 별도의 응답 데이터를 반환하지 않고, `204 No Content` 상태 코드를 사용하여 클라이언트에게 리뷰 등록이 정상적으로 처리되었음을 알립니다.