### PR TITLE
[#8] 제품 리뷰 조회 기능 구현

### DIFF
--- a/src/main/java/ksh/emall/common/config/ClockConfig.java
+++ b/src/main/java/ksh/emall/common/config/ClockConfig.java
@@ -1,0 +1,14 @@
+package ksh.emall.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/ksh/emall/member/entity/Member.java
+++ b/src/main/java/ksh/emall/member/entity/Member.java
@@ -1,0 +1,35 @@
+package ksh.emall.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import ksh.emall.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLDelete(sql = "update order set is_deleted = true where id = ?")
+@Where(clause = "isDeleted = 0")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    private String name;
+
+    private String nickname;
+}

--- a/src/main/java/ksh/emall/member/repository/MemberRepository.java
+++ b/src/main/java/ksh/emall/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package ksh.emall.member.repository;
+
+import ksh.emall.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/ksh/emall/review/controller/ReviewController.java
+++ b/src/main/java/ksh/emall/review/controller/ReviewController.java
@@ -1,20 +1,37 @@
 package ksh.emall.review.controller;
 
 import jakarta.validation.Valid;
+import ksh.emall.common.dto.response.PageResponseDto;
 import ksh.emall.review.dto.request.ReviewRegisterRequestDto;
+import ksh.emall.review.dto.request.ReviewRequestDto;
+import ksh.emall.review.dto.response.ReviewResponseDto;
 import ksh.emall.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class ReviewController {
 
     private final ReviewService reviewService;
+
+    @GetMapping("/products/{productId}")
+    public ResponseEntity<PageResponseDto> findReviewsOfProduct(
+        Pageable pageable,
+        @PathVariable("productId") long productId,
+        ReviewRequestDto request
+    ) {
+        Page<ReviewResponseDto> page = reviewService.findReviewsOfProduct(
+            pageable, productId, request)
+            .map(ReviewResponseDto::from);
+
+        var response = PageResponseDto.from(page);
+
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping("/products/{productId}/reviews")
     public ResponseEntity<Void> register(

--- a/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
+++ b/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
@@ -1,0 +1,40 @@
+package ksh.emall.review.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ReviewRequestDto {
+
+    @NotNull(message = "페이지 크기는 필수입니다.")
+    @Positive(message = "페이지 크기는 양수입니다.")
+    @Max(value = 15, message = "페이지 크기는 최대 15개 입니다.")
+    private Integer size;
+
+    @NotNull(message = "정렬 방향은 필수입니다.")
+    private Boolean isAscending;
+
+    @NotNull(message = "이전 페이지의 마지막 리뷰 id는 필수입니다.")
+    private Long lastId;
+
+    @Range(min = 0, max = 5, message = "이전 페이지의 마지막 리뷰 점수는 0이상 5이하입니다.")
+    private Integer lastScore;
+
+    private LocalDateTime lastRegisterTime;
+
+    @AssertTrue(message = "이전 페이지 마지막 리뷰의 점수와 등록 시각 중 하나만 입력해야 합니다.")
+    private boolean hasOnlyOne() {
+        boolean hasScore = this.lastScore != null;
+        boolean hasRegisterDate = this.lastRegisterTime != null;
+
+        return hasScore ^ hasRegisterDate;
+    }
+}

--- a/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
+++ b/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Range;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
@@ -28,12 +28,12 @@ public class ReviewRequestDto {
     @Range(min = 0, max = 5, message = "이전 페이지의 마지막 리뷰 점수는 0이상 5이하입니다.")
     private Integer lastScore;
 
-    private LocalDateTime lastRegisterTime;
+    private LocalDate lastRegisterDate;
 
-    @AssertTrue(message = "이전 페이지 마지막 리뷰의 점수와 등록 시각 중 하나만 입력해야 합니다.")
+    @AssertTrue(message = "이전 페이지 마지막 리뷰의 점수와 등록일 중 하나만 입력해야 합니다.")
     private boolean hasOnlyOne() {
         boolean hasScore = this.lastScore != null;
-        boolean hasRegisterDate = this.lastRegisterTime != null;
+        boolean hasRegisterDate = this.lastRegisterDate != null;
 
         return hasScore ^ hasRegisterDate;
     }

--- a/src/main/java/ksh/emall/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/ksh/emall/review/dto/response/ReviewResponseDto.java
@@ -1,0 +1,29 @@
+package ksh.emall.review.dto.response;
+
+import ksh.emall.member.entity.Member;
+import ksh.emall.review.entity.Review;
+import ksh.emall.review.repository.production.ReviewWithMember;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewResponseDto {
+
+    private String author;
+    private String title;
+    private String body;
+    private int likeCount;
+
+    public static ReviewResponseDto from(ReviewWithMember reviewWithMember) {
+        Review review = reviewWithMember.getReview();
+        Member member = reviewWithMember.getMember();
+
+        return ReviewResponseDto.builder()
+            .author(member.getNickname())
+            .title(review.getTitle())
+            .body(review.getBody())
+            .likeCount(review.getLikeCount())
+            .build();
+    }
+}

--- a/src/main/java/ksh/emall/review/entity/Review.java
+++ b/src/main/java/ksh/emall/review/entity/Review.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @Builder
@@ -30,6 +32,8 @@ public class Review extends BaseEntity {
     private String body;
 
     private Integer likeCount;
+
+    private LocalDate registerDate;
 
     private String imageUrl;
 

--- a/src/main/java/ksh/emall/review/repository/ReviewQueryRepository.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewQueryRepository.java
@@ -1,0 +1,11 @@
+package ksh.emall.review.repository;
+
+import ksh.emall.review.dto.request.ReviewRequestDto;
+import ksh.emall.review.repository.production.ReviewWithMember;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewQueryRepository {
+
+    Page<ReviewWithMember> findByProductIdAfterCursor(Pageable pageable, long productId, ReviewRequestDto request);
+}

--- a/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
@@ -5,7 +5,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.DatePath;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import ksh.emall.review.dto.request.ReviewRequestDto;
@@ -15,7 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import static ksh.emall.member.entity.QMember.member;
@@ -76,9 +76,9 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
             );
         }
 
-        return registerAtCursorPredicate(
-            review.createdAt,
-            request.getLastRegisterTime(),
+        return registerDateCursorPredicate(
+            review.registerDate,
+            request.getLastRegisterDate(),
             request.getLastId(),
             request.getIsAscending()
         );
@@ -100,9 +100,9 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
         return sameValuePredicate.or(nextPagePredicate);
     }
 
-    private BooleanExpression registerAtCursorPredicate(
-        DateTimePath<LocalDateTime> path,
-        LocalDateTime lastValue,
+    private BooleanExpression registerDateCursorPredicate(
+        DatePath<LocalDate> path,
+        LocalDate lastValue,
         long lastId,
         boolean isAscending
     ) {

--- a/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
@@ -1,0 +1,136 @@
+package ksh.emall.review.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ksh.emall.review.dto.request.ReviewRequestDto;
+import ksh.emall.review.repository.production.ReviewWithMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static ksh.emall.member.entity.QMember.member;
+import static ksh.emall.review.entity.QReview.review;
+
+@RequiredArgsConstructor
+public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
+
+    private JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Page<ReviewWithMember> findByProductIdAfterCursor(
+        Pageable pageable,
+        long productId,
+        ReviewRequestDto request
+    ) {
+        var cursorPredicate = cursorPredicate(pageable, request);
+
+        List<ReviewWithMember> content = queryFactory
+            .select(Projections.constructor(
+                ReviewWithMember.class,
+                review,
+                member
+            ))
+            .from(review)
+            .join(member).on(review.memberId.eq(member.id))
+            .where(
+                review.productId.eq(productId),
+                cursorPredicate
+            )
+            .orderBy(
+                cursorOrder(request),
+                review.id.asc()
+            )
+            .fetch();
+
+
+        return PageableExecutionUtils.getPage(
+            content,
+            pageable,
+            () -> totalCount(cursorPredicate)
+        );
+    }
+
+    private BooleanExpression cursorPredicate(
+        Pageable pageable,
+        ReviewRequestDto request
+    ) {
+        if (pageable.getPageNumber() == 0) return null;
+
+        if (request.getLastScore() != null) {
+            return scoreCursorPredicate(
+                review.score,
+                request.getLastScore(),
+                request.getLastId(),
+                request.getIsAscending()
+            );
+        }
+
+        return registerAtCursorPredicate(
+            review.createdAt,
+            request.getLastRegisterTime(),
+            request.getLastId(),
+            request.getIsAscending()
+        );
+    }
+
+    private <T extends Number & Comparable<? super T>> BooleanExpression scoreCursorPredicate(
+        NumberPath<T> path,
+        T lastValue,
+        long lastId,
+        boolean isAscending
+    ) {
+        BooleanExpression sameValuePredicate = path.eq(lastValue)
+            .and(review.id.gt(lastId));
+
+        BooleanExpression nextPagePredicate = isAscending
+            ? path.gt(lastValue)
+            : path.lt(lastValue);
+
+        return sameValuePredicate.or(nextPagePredicate);
+    }
+
+    private BooleanExpression registerAtCursorPredicate(
+        DateTimePath<LocalDateTime> path,
+        LocalDateTime lastValue,
+        long lastId,
+        boolean isAscending
+    ) {
+        BooleanExpression sameValuePredicate = path.eq(lastValue)
+            .and(review.id.gt(lastId));
+
+        BooleanExpression nextPagePredicate = isAscending
+            ? path.after(lastValue)
+            : path.before(lastValue);
+
+        return sameValuePredicate.or(nextPagePredicate);
+    }
+
+    private OrderSpecifier<?> cursorOrder(
+        ReviewRequestDto request
+    ) {
+        Order direction = request.getIsAscending() ? Order.ASC : Order.DESC;
+
+        return request.getLastScore() == null
+            ? new OrderSpecifier<>(direction, review.createdAt)
+            : new OrderSpecifier<>(direction, review.score);
+    }
+
+    private Long totalCount(Predicate where) {
+        return queryFactory
+            .select(review.count())
+            .from(review)
+            .where(where)
+            .fetchOne();
+    }
+}

--- a/src/main/java/ksh/emall/review/repository/ReviewRepository.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewRepository.java
@@ -3,5 +3,5 @@ package ksh.emall.review.repository;
 import ksh.emall.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryRepository {
 }

--- a/src/main/java/ksh/emall/review/repository/production/ReviewWithMember.java
+++ b/src/main/java/ksh/emall/review/repository/production/ReviewWithMember.java
@@ -1,0 +1,14 @@
+package ksh.emall.review.repository.production;
+
+import ksh.emall.member.entity.Member;
+import ksh.emall.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReviewWithMember {
+
+    private Review review;
+    private Member member;
+}

--- a/src/main/java/ksh/emall/review/service/ReviewService.java
+++ b/src/main/java/ksh/emall/review/service/ReviewService.java
@@ -14,6 +14,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
@@ -21,6 +24,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
     private final ProductReviewStatRepository productReviewStatRepository;
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public Page<ReviewWithMember> findReviewsOfProduct(
@@ -44,11 +48,15 @@ public class ReviewService {
         productReviewStat.addReviewScore(request.getScore());
     }
 
-    private static Review createReview(long productId, ReviewRegisterRequestDto request) {
+    private Review createReview(
+        long productId,
+        ReviewRegisterRequestDto request
+    ) {
         return Review.builder()
             .score(request.getScore())
             .title(request.getTitle())
             .body(request.getBody())
+            .registerDate(LocalDate.now(clock))
             .memberId(request.getMemberId())
             .productId(productId)
             .build();

--- a/src/main/java/ksh/emall/review/service/ReviewService.java
+++ b/src/main/java/ksh/emall/review/service/ReviewService.java
@@ -4,9 +4,13 @@ import ksh.emall.product.entity.ProductReviewStat;
 import ksh.emall.product.repository.ProductRepository;
 import ksh.emall.product.repository.ProductReviewStatRepository;
 import ksh.emall.review.dto.request.ReviewRegisterRequestDto;
+import ksh.emall.review.dto.request.ReviewRequestDto;
 import ksh.emall.review.entity.Review;
 import ksh.emall.review.repository.ReviewRepository;
+import ksh.emall.review.repository.production.ReviewWithMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +22,18 @@ public class ReviewService {
     private final ProductRepository productRepository;
     private final ProductReviewStatRepository productReviewStatRepository;
 
+    @Transactional(readOnly = true)
+    public Page<ReviewWithMember> findReviewsOfProduct(
+        Pageable pageable,
+        Long productId,
+        ReviewRequestDto request
+    ) {
+        return reviewRepository.findByProductIdAfterCursor(
+            pageable,
+            productId,
+            request
+        );
+    }
 
     @Transactional
     public void register(long productId, ReviewRegisterRequestDto request) {


### PR DESCRIPTION
# 주요 구현 사항
특정 제품의 리뷰를 커서 기반 페이징 방식으로 조회할 수 있는 기능을 구현했습니다.  
정렬 기준은 다음 두 가지 중 하나를 선택할 수 있으며 오름차순과 내림차순이 가능합니다.
- 별점(score) 순
- 등록일(registerDate) 순

## 요청 DTO
커서 기반 페이징을 위해 다음과 같은 정보를 요청합니다.
- lastId: 이전 페이지의 마지막 리뷰 ID
  - 평점과 등록 시각이 동일할 경우 를 위해 리뷰의 id는 반드시 포함합니다. 
- lastScore: 이전 페이지 마지막 리뷰의 별점
- lastRegisterDate: 이전 페이지 마지막 리뷰의 등록일

`@AssertTrue`를 이용해 `lastScore`와 `lastRegisterDate` 중 하나만 입력되었을 때만 유효하도록 검증합니다.  
이는 두 값이 동시에 입력될 경우, 평점과 등록일에 대한 조건이 함께 생성되는 것을 방지하기 위함입니다.

## QueryDSL 기반 동적 리뷰 조회 쿼리

해당 쿼리는 `score` 또는 `registerDate`를 기준으로 커서 기반 페이징을 수행하며, 오름차순 또는 내림차순 정렬을 지원합니다.  
단, `score`나 `registerDate` 값이 동일한 리뷰들 사이에서는 정렬 방향과 관계없이 항상 `id` 기준 오름차순 정렬을 적용합니다.

### sameValuePredicate

`sameValuePredicate`는 커서 기반 페이징을 위한 `BooleanExpression`을 생성하는 과정에서 사용하는 조건입니다.  
이는 `score`나 `registerDate`이 고유 식별자가 아니기 때문에 필요한 조건입니다.

#### 예시

이전 페이지의 마지막 리뷰의 `score`가 5이고, `score` 기준 내림차순 정렬을 요청한 경우 단순히 아래와 같은 조건을 where 절에 적용하면,

```sql
WHERE review.score < 5
```
동일한 5점 리뷰 중 일부만 조회되고, 나머지 5점 리뷰는 건너뛰고 4점 리뷰부터 조회하게 됩니다.

이러한 문제를 방지하기 위해 다음과 같은 조건을 구성합니다:

```sql
(review.score = 5 AND review.id > 39) OR (review.score < 5)
```
즉, 동점자 중 아직 조회되지 않은 항목을 id로 필터링하고, 다음 구간의 리뷰까지 포함하기 위해 OR로 결합하는 방식입니다.

커서 조건 정리을 정리하면 아래와 같습니다.
- 첫 페이지 요청 시: 조건 없음
- 이후 페이지 요청 시:
  - 동점자 조건: review.score = ? AND review.id > ?
  - 비동점자 조건: review.score < ? (또는 > 방향)
  - 두 조건을 OR로 묶어 where 절 구성

# TODO
제품과 리뷰에 대한 핵심 기능 구현을 어느정도 마쳤으며, 복잡한 동적 쿼리를 포함하고 있어 테스트 코드를 작성할 예정입니다.