### PR TITLE
[#11] 상품 조회 · 검색 및 리뷰 조회 · 등록 기능 버그 수정 및 리팩토링

### DIFF
--- a/src/main/java/ksh/emall/common/dto/request/PageRequestDto.java
+++ b/src/main/java/ksh/emall/common/dto/request/PageRequestDto.java
@@ -1,0 +1,30 @@
+package ksh.emall.common.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Slf4j
+@Getter
+@AllArgsConstructor
+public class PageRequestDto {
+
+    @NotNull(message = "페이지 번호는 필수입니다.")
+    @PositiveOrZero(message = "페이지 번호는 0 이상이어야 합니다.")
+    private Integer page;
+
+    @NotNull(message = "페이지 크기는 필수입니다.")
+    @Min(value = 1, message = "페이지 크기는 최소 1 이상이어야 합니다.")
+    @Max(value = 50, message = "페이지 크기는 최대 50입니다.")
+    private Integer size;
+
+    public Pageable toPageable() {
+        return PageRequest.of(page, size);
+    }
+}

--- a/src/main/java/ksh/emall/common/exception/ErrorCode.java
+++ b/src/main/java/ksh/emall/common/exception/ErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ErrorCode {
 
     PRODUCT_NOT_FOUND(404, "product.not.found"),
+    REVIEW_ALREADY_REGISTERED(400, "review.already.registered"),
 
     INTERNAL_SERVER_ERROR(500, "internal.server.error");
 

--- a/src/main/java/ksh/emall/member/entity/Member.java
+++ b/src/main/java/ksh/emall/member/entity/Member.java
@@ -17,8 +17,8 @@ import org.hibernate.annotations.Where;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@SQLDelete(sql = "update order set is_deleted = true where id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "update member set is_deleted = true where id = ?")
+@Where(clause = "is_deleted = false")
 public class Member extends BaseEntity {
 
     @Id
@@ -32,4 +32,6 @@ public class Member extends BaseEntity {
     private String name;
 
     private String nickname;
+
+    private boolean isDeleted;
 }

--- a/src/main/java/ksh/emall/product/controller/ProductController.java
+++ b/src/main/java/ksh/emall/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package ksh.emall.product.controller;
 
 import jakarta.validation.Valid;
+import ksh.emall.common.dto.request.PageRequestDto;
 import ksh.emall.common.dto.response.PageResponseDto;
 import ksh.emall.product.dto.request.ProductRequestDto;
 import ksh.emall.product.dto.request.ProductSearchConditionRequestDto;
@@ -8,7 +9,6 @@ import ksh.emall.product.dto.response.ProductResponseDto;
 import ksh.emall.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,11 +21,11 @@ public class ProductController {
 
     @GetMapping("/products")
     public ResponseEntity<PageResponseDto> findProductsByCategory(
-        Pageable pageable,
+        @Valid PageRequestDto pageRequest,
         @Valid ProductRequestDto productRequest
     ) {
         Page<ProductResponseDto> page = productService
-            .findProductsByCategory(pageable, productRequest)
+            .findProductsByCategory(pageRequest.toPageable(), productRequest)
             .map(ProductResponseDto::from);
 
         PageResponseDto<ProductResponseDto> response = PageResponseDto.from(page);
@@ -35,12 +35,12 @@ public class ProductController {
 
     @GetMapping("/products/search")
     public ResponseEntity<PageResponseDto> searchProductsWithConditions(
-        Pageable pageable,
+        @Valid PageRequestDto pageRequest,
         @Valid ProductRequestDto productRequest,
         @Valid ProductSearchConditionRequestDto productSearchRequestDto
     ) {
         Page<ProductResponseDto> page = productService.searchProducts(
-                pageable,
+                pageRequest.toPageable(),
                 productRequest,
                 productSearchRequestDto
             )

--- a/src/main/java/ksh/emall/product/dto/response/ProductResponseDto.java
+++ b/src/main/java/ksh/emall/product/dto/response/ProductResponseDto.java
@@ -30,7 +30,7 @@ public class ProductResponseDto {
             .price(product.getPrice())
             .deliveryType(product.getDeliveryType())
             .guaranteedDeliveryDate(LocalDate.now().plusDays(product.getExpectedDeliveryDays()))
-            .averageScore(reviewStat.getAverageReviewScore())
+            .averageScore(reviewStat.getAvgScore())
             .reviewCount(reviewStat.getReviewCount())
             .imageUrl(product.getImageUrl())
             .build();

--- a/src/main/java/ksh/emall/product/dto/response/ProductResponseDto.java
+++ b/src/main/java/ksh/emall/product/dto/response/ProductResponseDto.java
@@ -29,7 +29,7 @@ public class ProductResponseDto {
             .name(product.getName())
             .price(product.getPrice())
             .deliveryType(product.getDeliveryType())
-            .guaranteedDeliveryDate(LocalDate.now().plusDays(product.getExpectedDeliveryDays()))
+            .guaranteedDeliveryDate(product.getGuaranteedDeliveryDate())
             .averageScore(reviewStat.getAvgScore())
             .reviewCount(reviewStat.getReviewCount())
             .imageUrl(product.getImageUrl())

--- a/src/main/java/ksh/emall/product/entity/Product.java
+++ b/src/main/java/ksh/emall/product/entity/Product.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @Builder
@@ -40,4 +42,8 @@ public class Product extends BaseEntity {
     private String imageUrl;
 
     private boolean isDeleted;
+
+    public LocalDate getGuaranteedDeliveryDate() {
+        return LocalDate.now().plusDays(this.expectedDeliveryDays);
+    }
 }

--- a/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
+++ b/src/main/java/ksh/emall/product/entity/ProductReviewStat.java
@@ -25,7 +25,9 @@ public class ProductReviewStat extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Double averageReviewScore;
+    private Double avgScore;
+
+    private Integer totalScore;
 
     private Integer reviewCount;
 
@@ -36,11 +38,13 @@ public class ProductReviewStat extends BaseEntity {
     public void addReviewScore(int newScore) {
         if(reviewCount == 0){
             this.reviewCount = 0;
-            this.averageReviewScore = 0.0;
+            this.totalScore = 0;
+            this.avgScore = 0.0;
         }
 
-        double totalScore = this.averageReviewScore * this.reviewCount;
+        this.totalScore += newScore;
         this.reviewCount++;
-        this.averageReviewScore = (totalScore + newScore) / this.reviewCount;
+
+        this.avgScore = (double) totalScore / reviewCount;
     }
 }

--- a/src/main/java/ksh/emall/product/repository/ProductQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/product/repository/ProductQueryRepositoryImpl.java
@@ -131,7 +131,7 @@ public class ProductQueryRepositoryImpl implements ProductQueryRepository {
     private BooleanExpression reviewScorePredicate(Integer score) {
         if (score == null) return null;
 
-        var avgScore = productReviewStat.averageReviewScore;
+        var avgScore = productReviewStat.avgScore;
 
         var lower = avgScore.goe(score);
         var upper = score < 4 ? avgScore.lt(score + 1) : avgScore.loe(score + 1);

--- a/src/main/java/ksh/emall/review/controller/ReviewController.java
+++ b/src/main/java/ksh/emall/review/controller/ReviewController.java
@@ -18,7 +18,7 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @GetMapping("/products/{productId}")
+    @GetMapping("/products/{productId}/reviews")
     public ResponseEntity<PageResponseDto> findReviewsOfProduct(
         @Valid PageRequestDto pageRequest,
         @PathVariable("productId") long productId,

--- a/src/main/java/ksh/emall/review/controller/ReviewController.java
+++ b/src/main/java/ksh/emall/review/controller/ReviewController.java
@@ -22,7 +22,7 @@ public class ReviewController {
     public ResponseEntity<PageResponseDto> findReviewsOfProduct(
         @Valid PageRequestDto pageRequest,
         @PathVariable("productId") long productId,
-        ReviewRequestDto request
+        @Valid ReviewRequestDto request
     ) {
         Page<ReviewResponseDto> page = reviewService.findReviewsOfProduct(
             pageRequest.toPageable(), productId, request)

--- a/src/main/java/ksh/emall/review/controller/ReviewController.java
+++ b/src/main/java/ksh/emall/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package ksh.emall.review.controller;
 
 import jakarta.validation.Valid;
+import ksh.emall.common.dto.request.PageRequestDto;
 import ksh.emall.common.dto.response.PageResponseDto;
 import ksh.emall.review.dto.request.ReviewRegisterRequestDto;
 import ksh.emall.review.dto.request.ReviewRequestDto;
@@ -8,7 +9,6 @@ import ksh.emall.review.dto.response.ReviewResponseDto;
 import ksh.emall.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,12 +20,12 @@ public class ReviewController {
 
     @GetMapping("/products/{productId}")
     public ResponseEntity<PageResponseDto> findReviewsOfProduct(
-        Pageable pageable,
+        @Valid PageRequestDto pageRequest,
         @PathVariable("productId") long productId,
         ReviewRequestDto request
     ) {
         Page<ReviewResponseDto> page = reviewService.findReviewsOfProduct(
-            pageable, productId, request)
+            pageRequest.toPageable(), productId, request)
             .map(ReviewResponseDto::from);
 
         var response = PageResponseDto.from(page);

--- a/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
+++ b/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
@@ -2,6 +2,7 @@ package ksh.emall.review.dto.request;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import ksh.emall.review.enums.sort.ReviewSortCriteria;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Range;
@@ -11,6 +12,9 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor
 public class ReviewRequestDto {
+
+    @NotNull(message = "정렬 기준은 필수입니다.")
+    private ReviewSortCriteria criteria;
 
     @NotNull(message = "정렬 방향은 필수입니다.")
     private Boolean isAscending;

--- a/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
+++ b/src/main/java/ksh/emall/review/dto/request/ReviewRequestDto.java
@@ -1,9 +1,7 @@
 package ksh.emall.review.dto.request;
 
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Range;
@@ -13,11 +11,6 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor
 public class ReviewRequestDto {
-
-    @NotNull(message = "페이지 크기는 필수입니다.")
-    @Positive(message = "페이지 크기는 양수입니다.")
-    @Max(value = 15, message = "페이지 크기는 최대 15개 입니다.")
-    private Integer size;
 
     @NotNull(message = "정렬 방향은 필수입니다.")
     private Boolean isAscending;

--- a/src/main/java/ksh/emall/review/entity/Review.java
+++ b/src/main/java/ksh/emall/review/entity/Review.java
@@ -16,8 +16,8 @@ import java.time.LocalDate;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@SQLDelete(sql = "update order set is_deleted = true where id = ?")
-@Where(clause = "isDeleted = 0")
+@SQLDelete(sql = "update review set is_deleted = true where id = ?")
+@Where(clause = "is_deleted = false")
 public class Review extends BaseEntity {
 
     @Id

--- a/src/main/java/ksh/emall/review/enums/sort/ReviewSortCriteria.java
+++ b/src/main/java/ksh/emall/review/enums/sort/ReviewSortCriteria.java
@@ -1,0 +1,6 @@
+package ksh.emall.review.enums.sort;
+
+public enum ReviewSortCriteria {
+    SCORE,
+    REGISTER_DATE,
+}

--- a/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
@@ -104,9 +104,11 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     private BooleanExpression registerDateCursorPredicate(
         DatePath<LocalDate> path,
         LocalDate lastValue,
-        long lastId,
+        Long lastId,
         boolean isAscending
     ) {
+        if(lastId == null) return null;
+
         BooleanExpression sameValuePredicate = path.eq(lastValue)
             .and(review.id.gt(lastId));
 

--- a/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.dsl.DatePath;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import ksh.emall.review.dto.request.ReviewRequestDto;
+import ksh.emall.review.enums.sort.ReviewSortCriteria;
 import ksh.emall.review.repository.projection.ReviewWithMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -124,9 +125,9 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     ) {
         Order direction = request.getIsAscending() ? Order.ASC : Order.DESC;
 
-        return request.getLastScore() == null
-            ? new OrderSpecifier<>(direction, review.createdAt)
-            : new OrderSpecifier<>(direction, review.score);
+        return request.getCriteria() == ReviewSortCriteria.SCORE
+            ? new OrderSpecifier<>(direction, review.score)
+            : new OrderSpecifier<>(direction, review.registerDate);
     }
 
     private Long totalCount(Predicate where) {

--- a/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
@@ -24,7 +24,7 @@ import static ksh.emall.review.entity.QReview.review;
 @RequiredArgsConstructor
 public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
 
-    private JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
 
     @Override

--- a/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewQueryRepositoryImpl.java
@@ -51,6 +51,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
                 cursorOrder(request),
                 review.id.asc()
             )
+            .limit(pageable.getPageSize())
             .fetch();
 
 

--- a/src/main/java/ksh/emall/review/repository/ReviewRepository.java
+++ b/src/main/java/ksh/emall/review/repository/ReviewRepository.java
@@ -4,4 +4,6 @@ import ksh.emall.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryRepository {
+
+    boolean existsByProductIdAndMemberId(Long productId, Long memberId);
 }

--- a/src/main/java/ksh/emall/review/service/ReviewService.java
+++ b/src/main/java/ksh/emall/review/service/ReviewService.java
@@ -40,12 +40,13 @@ public class ReviewService {
     }
 
     @Transactional
-    public void register(long productId, ReviewRegisterRequestDto request) {
+    public Review register(long productId, ReviewRegisterRequestDto request) {
         productRepository.getById(productId);
         Review review = createReview(productId, request);
         reviewRepository.save(review);
         ProductReviewStat productReviewStat = productReviewStatRepository.getByProductId(productId);
         productReviewStat.addReviewScore(request.getScore());
+        return review;
     }
 
     private Review createReview(

--- a/src/main/java/ksh/emall/review/service/ReviewService.java
+++ b/src/main/java/ksh/emall/review/service/ReviewService.java
@@ -1,5 +1,7 @@
 package ksh.emall.review.service;
 
+import ksh.emall.common.exception.CustomException;
+import ksh.emall.common.exception.ErrorCode;
 import ksh.emall.product.entity.ProductReviewStat;
 import ksh.emall.product.repository.ProductRepository;
 import ksh.emall.product.repository.ProductReviewStatRepository;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -42,10 +45,22 @@ public class ReviewService {
     @Transactional
     public Review register(long productId, ReviewRegisterRequestDto request) {
         productRepository.getById(productId);
+
+        boolean duplicated = reviewRepository.existsByProductIdAndMemberId(
+            productId,
+            request.getMemberId()
+        );
+        if (duplicated) {
+            throw new CustomException(ErrorCode.REVIEW_ALREADY_REGISTERED);
+        }
+
+
         Review review = createReview(productId, request);
         reviewRepository.save(review);
+
         ProductReviewStat productReviewStat = productReviewStatRepository.getByProductId(productId);
         productReviewStat.addReviewScore(request.getScore());
+
         return review;
     }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,3 +1,4 @@
 product.not.found={0}는 존재하지 않는 제품입니다.
+review.already.registered=해당 제품에는 이미 리뷰를 작성했습니다.
 
 internal.server.error=서버 내부에 문제가 발생했습니다.


### PR DESCRIPTION
# 주요 수정 사항

## 상품 조회 · 검색  
- 컨트롤러에 있던 보장 도착일 계산 로직을 엔티티로 이동합니다.

## 리뷰 조회  
- 커서 기반 페이징에서도 페이지 크기만큼만 데이터를 가져오도록 `limit` 조건을 추가합니다.  
- 첫 번째 페이지는 이전 페이지가 없기 때문에 `lastId`가 `null`일 수 있어, 이를 고려해 타입을 `Long`으로 변경합니다.  
- 요청값에 정렬 기준을 추가하여 동적 정렬 기준을 생성할 수 있도록 합니다.  
  - 기존에는 `lastScore`의 유무로 정렬 기준을 판단했으나, 첫 페이지의 경우 해당 기준만으로는 적용 여부를 명확히 판단할 수 없습니다.

## 리뷰 등록  
- 리뷰 통계에 점수 총합 필드를 추가합니다.  
  - 총합이 없으면 리뷰 평점 갱신 시 소수점 문제로 정확한 계산이 어렵습니다.  
  - 평균 점수만 존재하면 인덱스 활용이 어려워 성능에 영향을 줄 수 있습니다.  
  - 따라서 평균 점수와 총점을 모두 필드로 유지합니다.  
- 누락되었던 리뷰 중복 작성 방지 로직을 추가합니다.

## 공통  
- 페이징 요청 정보를 담는 DTO를 생성하여 요청값 검증이 가능하도록 합니다.  
- 자동 soft delete가 적용되지 않던 버그를 수정합니다.  
  - 엔티티에 맞게 테이블명을 수정합니다.  
  - `isDelete = 0`에서 `is_delete = false`로 필드명을 변경합니다.
